### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tvheadend IPTV Config
 [![GitHub license](https://img.shields.io/github/license/Josh5/TVH-IPTV-Config?color=009dc7&style=flat-square)]()
 ---
 
-Tvheadend IPTV Config is a simple wrapper around Tvheadned with the singular goal of making it simple to configure Tvheadend for IPTV playlist.
+Tvheadend IPTV Config is a simple wrapper around Tvheadend with the singular goal of making it simple to configure Tvheadend for IPTV playlist.
 
 Tvheadend is an extremely powerful TV streaming server and recorder with excellent support for IPTV sources. However, for most people, setting this up can be difficult and time-consuming.
 The goal of this project is to wrap around Tvheadend and, using its API, configure most of the server for you.


### PR DESCRIPTION
There's a typo in the README.md, spelling `Tvheadned` instead of`Tvheadend`