### PR TITLE
feat: Add group title as tag during bulk channel add

### DIFF
--- a/backend/channels.py
+++ b/backend/channels.py
@@ -452,6 +452,11 @@ async def add_bulk_channels(config, data):
         new_channel_data['logo_url'] = playlist_stream.tvg_logo
         # Auto assign the channel number to the next available number
         new_channel_data['number'] = int(channel_number)
+        
+        # Add group title as tag if it exists
+        if playlist_stream.group_title and playlist_stream.group_title.strip():
+            new_channel_data['tags'].append(playlist_stream.group_title.strip())
+        
         # Find the best match for an EPG
         epg_match = db.session.query(EpgChannels).filter(EpgChannels.channel_id == playlist_stream.tvg_id).first()
         if epg_match is not None:


### PR DESCRIPTION
This commit adds the group title from the playlist stream as a tag to the channel when adding channels in bulk. This allows users to easily filter and organize channels based on their group.

Key changes include:

- Added logic to extract the group title from the `playlist_stream` object.
- Appended the group title to the `tags` list of the `new_channel_data` dictionary if it exists and is not empty.